### PR TITLE
rmatch: Fix PHP Warning on PHP 8

### DIFF
--- a/ExtRegexFunctions.php
+++ b/ExtRegexFunctions.php
@@ -171,7 +171,10 @@ class ExtRegexFunctions {
 					return $matches[$backRefs[1]];
 				}
 
-				if ( $backRefs[2] !== '' && array_key_exists( $backRefs[2], $matches ) ) {
+				if (
+					isset( $backRefs[2] ) &&
+					$backRefs[2] !== '' &&
+					array_key_exists( $backRefs[2], $matches ) ) {
 					return $matches[$backRefs[2]];
 				}
 


### PR DESCRIPTION
Ensure the second backreference is defined, otherwise backreference substitution will emit 'PHP Warning: Undefined array key 2 in /extensions/RegexFunctions/ExtRegexFunctions.php on line 174' when no matches were found.